### PR TITLE
BugFix: undefined variable for layer 1/2 implementation

### DIFF
--- a/src/train.lua
+++ b/src/train.lua
@@ -232,9 +232,10 @@ function train(train_data, epoch)
         if classifier_opt.verbose then print('forward fwd encoder') end
         for t = 1, source_l do
           -- run through encoder if using representations above word vectors or if need it for decoder
+          local enc_out
           if classifier_opt.enc_layer > 0 or classifier_opt.enc_or_dec == 'dec' then
             local encoder_input = {source_input[t], table.unpack(rnn_state_enc)}
-            local enc_out = encoder:forward(encoder_input)
+            enc_out = encoder:forward(encoder_input)
             rnn_state_enc = enc_out
             if classifier_opt.verbose then
               print('t: ' .. t)


### PR DESCRIPTION
A variable (`enc_out`) was defined locally to an if block, while
another if block later was trying to use the same variable. This
bug only surfaced when using layer 1 or 2. Moved declaration of
`enc_out` to outside both if blocks as a fix.